### PR TITLE
Allow launch arguments to be passed to start() as array

### DIFF
--- a/lib/hl-engine.js
+++ b/lib/hl-engine.js
@@ -33,8 +33,8 @@ window.onerror = function(event) {
 };
 
 /**
- * 
- * @param {ArrayBuffer} data: Zip to mount 
+ *
+ * @param {ArrayBuffer} data: Zip to mount
  * @param {String} [folder]: Optional subpath to mount the zip at, for example `valve`
  */
 function mountZIP(data, folder)
@@ -151,7 +151,7 @@ function start(params)
   console.log("Starting with params: "+JSON.stringify(params));
 
   setupFS(params.filesystem);
-  
+
   let args = [];
   if(params.mod) {
     args.push("-game");
@@ -161,8 +161,9 @@ function start(params)
     args.push("+map");
     args.push(params.map);
   }
-  Module.arguments = args
-  
+
+  Module.arguments = [...args, ...params.args];
+
   Module.run = run = savedRun;
 
   if(params.zip) {


### PR DESCRIPTION
Like so:

```js
const DEFAULT_ARGS = [
  `-height`,
  `${window.innerHeight}`,
  `-width`,
  `${window.innerWidth}`,
  `+hud_scale`,
  `2.5`,
];

const launchOptionsString = '+volume 0.3 +hud_scale 2.5'

const params = {
      mod: selectedGame,
      map: null,
      filesystem: "RAM",
      fullscreen: false,
      zip,
      args: [...DEFAULT_ARGS, ...launchOptions.value.split(" ")],
    };
    start(params);
}
```